### PR TITLE
Make sure signals are reconnected even when decorated function fails

### DIFF
--- a/signal_disabler/signal_disabler.py
+++ b/signal_disabler/signal_disabler.py
@@ -21,8 +21,10 @@ class disable(object):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             self.disconnect_all()
-            fn(*args, **kwargs)
-            self.reconnect_all()
+            try:
+                fn(*args, **kwargs)
+            finally:
+                self.reconnect_all()
         return decorated
 
     def __enter__(self):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -29,3 +29,20 @@ def test_fail_as_uninstantiated_decorator(db):
 
     with pytest.raises(AttributeError):
         save()
+
+
+def test_signals_reconnected_after_exception(db):
+    obj = CustomModel()
+
+    @signal_disabler.disable()
+    def fails():
+        raise Exception
+
+    try:
+        fails()
+    except:
+        pass
+
+    with pytest.raises(PostSaveCalled):
+        obj.save()
+


### PR DESCRIPTION
## Goal
Whenever a decorated function raised an exception, the code to reconnect signals wasn't executed, which affected code that did rely on signals, which can affect unrelated tests and make them fail. We want to make sure we always reconnect them.

## Changes
- Added a test that verifies that even when a decorated function raises an exception, the signals are reconnected again
- Surrounded function call inside decorator with a `try..except` block and reconnected signals in the `finally` clause